### PR TITLE
Fix musicview link highlighting glitch

### DIFF
--- a/frescobaldi_app/musicview/pointandclick.py
+++ b/frescobaldi_app/musicview/pointandclick.py
@@ -34,7 +34,7 @@ import util
 import textedit
 import pointandclick
 
-from PyQt6.QtCore import QRectF
+from PyQt6.QtCore import QPointF, QRectF
 
 
 # cache point and click handlers for poppler documents
@@ -53,7 +53,7 @@ def links(document):
                         t = textedit.link(link.url)
                         if t:
                             filename = util.normpath(t.filename)
-                            area = QRectF(*link.area)
+                            area = QRectF(QPointF(*link.area[0:2]), QPointF(*link.area[2:4]))
                             l.add_link(filename, t.line, t.column, (num, area))
         return l
 


### PR DESCRIPTION
(Opening a separate PR, because it's not just another trivial property name fix and I'm not 100% sure if this fix is correct or if the issue should be addressed upstream, e.g. somewhere in qpageview.)

The screenshot shows two highlighting rectangles within each other, both for the same pdf link. The small, correctly sized one is triggered by mouse pointer hovering over the link; the oversized one is triggered by editor cursor moving to a position corresponding to the pdf link. (Also triggered by clicking the pdf link. If I read the code correctly, there isn't highlighting implemented separately for the link click event, but is triggered by the fact that link click moves the editor cursor, which in turn triggers element highlighting in the musicview.)

![2024-08-19-114451_1366x768_scrot](https://github.com/user-attachments/assets/56deb4b7-0e83-4647-b26c-05bac7312e35)

The issue isn't about unit conversion (51cb408e), but about `QRectF` arguments being `(x, y, width, height)`, while `link.area` contains `(x1, y1, x2, y2)`