### PR TITLE
Don't crash when engraving job is aborted

### DIFF
--- a/frescobaldi_app/job/__init__.py
+++ b/frescobaldi_app/job/__init__.py
@@ -404,14 +404,13 @@ class Job:
         Outputs a message on completion of the process.
 
         """
-        if exitStatus == QProcess.ExitStatus.NormalExit:
-            if exitCode:
-                self.message(_("Exited with return code {code}.").format(code=exitCode), FAILURE)
-            else:
-                time = self.elapsed2str(self.elapsed_time())
-                self.message(_("Completed successfully in {time}.").format(time=time), SUCCESS)
-        else:
+        if exitCode:
+            self.message(_("Exited with return code {code}.").format(code=exitCode), FAILURE)
+        elif exitStatus:
             self.message(_("Exited with exit status {status}.").format(status=exitStatus), FAILURE)
+        else:
+            time = self.elapsed2str(self.elapsed_time())
+            self.message(_("Completed successfully in {time}.").format(time=time), SUCCESS)
 
     @staticmethod
     def elapsed2str(seconds):

--- a/frescobaldi_app/job/__init__.py
+++ b/frescobaldi_app/job/__init__.py
@@ -406,7 +406,7 @@ class Job:
         """
         if exitCode:
             self.message(_("Exited with return code {code}.").format(code=exitCode), FAILURE)
-        elif exitStatus:
+        elif exitStatus != QProcess.ExitStatus.NormalExit:
             self.message(_("Exited with exit status {status}.").format(status=exitStatus), FAILURE)
         else:
             time = self.elapsed2str(self.elapsed_time())


### PR DESCRIPTION
In addition to fixing the crash scenario I dared to revert one of your commits, since the reworked error message was significantly less useful than I got used to during the long years of using Frescobaldi. The process exit code is an essential piece of information and in error scenarios I definitely like to see it if available.