### PR TITLE
Fix undesirable pointandclick Links cache hits

### DIFF
--- a/frescobaldi_app/musicview/pointandclick.py
+++ b/frescobaldi_app/musicview/pointandclick.py
@@ -42,10 +42,14 @@ _cache = weakref.WeakKeyDictionary()
 
 
 def links(document):
+    # the backend (QPdf/poppler) object is replaced on every load
+    # of the pdf, which makes it a suitable cache key
+    key = document.document()
+
     try:
-        return _cache[document]
+        return _cache[key]
     except KeyError:
-        l = _cache[document] = Links()
+        l = _cache[key] = Links()
         with l:
             with qpageview.locking.lock(document):
                 for num, page in enumerate(document.pages()):


### PR DESCRIPTION
This is a minimal fix of the issue reported [here](https://github.com/frescobaldi/frescobaldi/pull/1780#discussion_r1735411932).

I agree that

> Frescobaldi shouldn't be messing with backend types like `popplerqt5.Poppler.Document` at all

but I tend to think that this kind of use is tolerable. The backend object is not communicated directly with, we only know that it's there and is replaced on every reload.